### PR TITLE
clear non numerical values (units) from snmp query

### DIFF
--- a/nagios-plugins/check_snmp_memory.pl
+++ b/nagios-plugins/check_snmp_memory.pl
@@ -72,12 +72,15 @@ sub do_snmp {
 	}
 
 	my $type;
+	
+	my $unit;
 
 	my ($jnk, $x) = split / = /, $out, 2;
 
-	if ($x =~ /([a-zA-Z0-9]+): (.*)$/) {
+	if ($x =~ /([a-zA-Z0-9]+): ([0-9]*)(.*)$/) {
 		$type = $1;
 		$x = $2;
+		$unit = $3;
 	}
 
 	return $x;


### PR DESCRIPTION
In some old snmpd the return value has also the unit so the plugin fail with some warnings when make arithmetic operations.